### PR TITLE
Migrate @actions/github from 4.0.0 to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actionbot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Github Action Policy Checker as a Github Action",
   "main": "lib/index.js",

--- a/src/github_files.ts
+++ b/src/github_files.ts
@@ -13,7 +13,7 @@ export async function getFilesInCommit(commit: any, token: string): Promise<stri
 
     const octokit = github.getOctokit(token);
     console.log('octokit : ' + octokit);
-    const result = await octokit.repos.getCommit(args);
+    const result = await octokit.rest.repos.getCommit(args);
     console.log('result : ' + result);
 
     if (result && result.data && result.data.files) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ async function run(context: typeof github.context): Promise<void> {
         if (prNumber) {
           console.log('prNumber : ' + prNumber);
           // Fetch the pull request details to get the commits_url
-          const prDetails = await client.pulls.get({
+          const prDetails = await client.rest.pulls.get({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             pull_number: prNumber,
@@ -97,7 +97,7 @@ async function run(context: typeof github.context): Promise<void> {
         if (prNumber2) {
           console.log('prNumber2 : ' + prNumber2);
           // Fetch the pull request details to get the commits_url
-          const prDetails2 = await client.pulls.get({
+          const prDetails2 = await client.rest.pulls.get({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             pull_number: prNumber2,


### PR DESCRIPTION
This PR finishes the migration of @actions/github from version 4.0.0 to 6.0.0.

The only notable change is the change of octokit.{endpoint} to octokit.rest.{endpoint}.